### PR TITLE
fix: overlapping droppable with non matching dropScope steals drop event

### DIFF
--- a/src/directives/droppable.directive.ts
+++ b/src/directives/droppable.directive.ts
@@ -151,14 +151,18 @@ export class Droppable implements OnInit, OnDestroy {
 
     @HostListener('drop', ['$event'])
     drop(e) {
-        DomHelper.removeClass(this.el, this.dragOverClass);
-        e.preventDefault();
-        e.stopPropagation();
+        this.allowDrop().subscribe(result => {
+            if (result && this._isDragActive) {
+                DomHelper.removeClass(this.el, this.dragOverClass);
+                e.preventDefault();
+                e.stopPropagation();
 
-        this.ng2DragDropService.onDragEnd.next();
-        this.onDrop.emit(new DropEvent(e, this.ng2DragDropService.dragData));
-        this.ng2DragDropService.dragData = null;
-        this.ng2DragDropService.scope = null;
+                this.ng2DragDropService.onDragEnd.next();
+                this.onDrop.emit(new DropEvent(e, this.ng2DragDropService.dragData));
+                this.ng2DragDropService.dragData = null;
+                this.ng2DragDropService.scope = null;
+            }
+        });
     }
 
     allowDrop(): Observable<boolean> {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When a parent and child element both are droppable and have a dropScope which does not match, the child element steals (i.e. handles) the drop event when the dragScope matches that of the parent element.


* **What is the new behavior (if this is a feature change)?**
After the fix is applied the handling of the drop event is only carried out when the the dragScope matches the dropScope.